### PR TITLE
Remove unused Finnhub integration

### DIFF
--- a/core/cipher.py
+++ b/core/cipher.py
@@ -42,4 +42,4 @@ class AESCipherPass:
 def hash_text(text, method='sha256'):
     h = getattr(hashlib, method)()
     h.update(text.encode('utf-8'))
-    return h.hexdigest()       
+    return h.hexdigest()

--- a/core/services.py
+++ b/core/services.py
@@ -1,8 +1,7 @@
 import yfinance as yf
-import requests
 from core.calc import calculate_rsi, calculate_ma, calculate_macd
 
-def get_ticker_data(ticker_symbol: str, api_key: str | None = None) -> dict:
+def get_ticker_data(ticker_symbol: str) -> dict:
     ticker_symbol = ticker_symbol.upper()
     try:
         ticker = yf.Ticker(ticker_symbol)
@@ -44,61 +43,9 @@ def get_ticker_data(ticker_symbol: str, api_key: str | None = None) -> dict:
             "MACD Signal": macd_signal,
         }
 
-        if api_key:
-            quote = fetch_finnhub_quote(ticker_symbol, api_key)
-            profile = fetch_finnhub_profile(ticker_symbol, api_key)
-            if quote:
-                if "error" in quote:
-                    data["Finnhub"] = quote
-                else:
-                    data["Finnhub Quote"] = quote
-            if profile:
-                if "error" in profile:
-                    data["Finnhub"] = profile
-                else:
-                    data["Finnhub Profile"] = profile
-
         return data
 
     except Exception as e:
         return {"error": f"Failed to fetch data for {ticker_symbol}: {str(e)}"}
 
 
-
-def fetch_finnhub_quote(symbol: str, api_key: str) -> dict | None:
-    url = "https://finnhub.io/api/v1/quote"
-    try:
-        resp = requests.get(url, params={"symbol": symbol, "token": api_key}, timeout=5)
-        if resp.status_code == 200:
-            q = resp.json()
-            return {
-                "Current": q.get("c"),
-                "High": q.get("h"),
-                "Low": q.get("l"),
-                "Open": q.get("o"),
-                "Prev Close": q.get("pc"),
-            }
-        if resp.status_code in (401, 403):
-            return {"error": "invalid key"}
-    except Exception:
-        pass
-    return None
-
-
-def fetch_finnhub_profile(symbol: str, api_key: str) -> dict | None:
-    url = "https://finnhub.io/api/v1/stock/profile2"
-    try:
-        resp = requests.get(url, params={"symbol": symbol, "token": api_key}, timeout=5)
-        if resp.status_code == 200:
-            p = resp.json()
-            return {
-                "Name": p.get("name"),
-                "Exchange": p.get("exchange"),
-                "Industry": p.get("finnhubIndustry"),
-                "MarketCap": p.get("marketCapitalization"),
-            }
-        if resp.status_code in (401, 403):
-            return {"error": "invalid key"}
-    except Exception:
-        pass
-    return None

--- a/core/utils.py
+++ b/core/utils.py
@@ -17,7 +17,7 @@ def bootcheck():
         ciphered_pw = AESCipherPass.encrypt(default_pass, "default")
         hashed = hash_text(ciphered_pw)
         enc_pass_hash = AESCipherPass.encrypt(hashed, default_pass)
-        data = {"users": {enc_user: {"password": enc_pass_hash, "finnhub": ""}}}
+        data = {"users": {enc_user: {"password": enc_pass_hash}}}
         with accounts_file.open("w", encoding="utf-8") as f:
             json.dump(data, f, indent=4)
 
@@ -57,7 +57,7 @@ def create_account(username: str, pw1: str, pw2: str, accounts_file: Path | str)
     ciphered_pw = AESCipherPass.encrypt(pw1, "default")
     hashed_pw = hash_text(ciphered_pw)
     enc_pw = AESCipherPass.encrypt(hashed_pw, pw1)
-    users[enc_user] = {"password": enc_pw, "finnhub": ""}
+    users[enc_user] = {"password": enc_pw}
     _save_users(accounts_file, users)
     return True, "Account created"
 

--- a/ui/panels/panel_main.py
+++ b/ui/panels/panel_main.py
@@ -1,7 +1,6 @@
 import tkinter as tk
 import json
 from core.services import get_ticker_data
-from core.cipher import AESCipherPass
 
 class MainPanel(tk.Frame):
     def __init__(self, parent, app):
@@ -31,12 +30,8 @@ class MainPanel(tk.Frame):
         self.output_text.delete("1.0", tk.END)
         if query:
             tickers = [t.strip() for t in query.replace(",", " ").split() if t.strip()]
-            api_key = self._get_api_key()
-            if not api_key:
-                self.output_text.configure(state="disabled")
-                return
             for idx, ticker in enumerate(tickers):
-                data = get_ticker_data(ticker, api_key=api_key)
+                data = get_ticker_data(ticker)
                 if isinstance(data, dict):
                     if "error" in data:
                         self.output_text.insert(tk.END, data["error"])
@@ -48,23 +43,6 @@ class MainPanel(tk.Frame):
         else:
             self.save_button.configure(state="disabled")
         self.output_text.configure(state="disabled")
-
-    def _get_api_key(self):
-        try:
-            with open(self.app.accounts_file, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except Exception:
-            return None
-
-        users = data.get("users", {})
-        user_data = users.get(self.app.current_user_enc, {})
-        enc_key = user_data.get("finnhub", "")
-        if enc_key and self.app.current_password:
-            try:
-                return AESCipherPass.decrypt(enc_key, self.app.current_password)
-            except Exception:
-                return None
-        return None
 
     def _save_text(self):
         text = self.output_text.get("1.0", tk.END).strip()

--- a/ui/panels/panel_settings.py
+++ b/ui/panels/panel_settings.py
@@ -1,61 +1,11 @@
 import tkinter as tk
-from tkinter import messagebox
-import json
-from core.cipher import AESCipherPass
 
 class SettingsPanel(tk.Frame):
     def __init__(self, parent, app):
         super().__init__(parent, bg="white")
         self.app = app
+        tk.Label(self, text="Settings", bg="white").pack(pady=(20, 10))
+        tk.Button(self, text="Back", command=self._back).pack()
 
-        tk.Label(self, text="Finnhub API Key", bg="white").pack(pady=(20, 5))
-        self.api_var = tk.StringVar()
-
-        try:
-            with open(self.app.accounts_file, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except Exception:
-            data = {}
-
-        users = data.get("users", {})
-        user_data = users.get(self.app.current_user_enc, {})
-        enc_key = user_data.get("finnhub", "")
-        key_plain = ""
-        if enc_key and self.app.current_password:
-            try:
-                key_plain = AESCipherPass.decrypt(enc_key, self.app.current_password)
-            except Exception:
-                key_plain = ""
-        self.api_var.set(key_plain)
-
-        tk.Entry(self, textvariable=self.api_var).pack(fill="x", padx=10)
-
-        btn_frame = tk.Frame(self, bg="white")
-        btn_frame.pack(pady=10)
-
-        tk.Button(btn_frame, text="Cancel", command=self._cancel).pack(side="left", padx=5)
-        tk.Button(btn_frame, text="Save", command=self._save).pack(side="left", padx=5)
-
-    def _save(self):
-        key = self.api_var.get().strip()
-        try:
-            with open(self.app.accounts_file, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except Exception:
-            data = {}
-
-        users = data.get("users", {})
-        user_data = users.get(self.app.current_user_enc, {})
-        enc_key = ""
-        if key:
-            enc_key = AESCipherPass.encrypt(key, self.app.current_password or "")
-        user_data["finnhub"] = enc_key
-        users[self.app.current_user_enc] = user_data
-        data["users"] = users
-        with open(self.app.accounts_file, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=4)
-        messagebox.showinfo("Saved", "Settings saved")
-        self.app.show_main()
-
-    def _cancel(self):
+    def _back(self):
         self.app.show_main()


### PR DESCRIPTION
## Summary
- strip out Finnhub API usage
- simplify main panel search
- keep empty settings panel placeholder
- clean up account bootstrapping

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687fab8c18b083258900eca696c46f36