### PR TITLE
Add options chain summary and better search output

### DIFF
--- a/core/calc.py
+++ b/core/calc.py
@@ -31,3 +31,67 @@ def calculate_macd(
     if macd.empty or signal.empty:
         return None, None
     return round(macd.iloc[-1], 2), round(signal.iloc[-1], 2)
+
+
+def summarize_option_chain(
+    ticker_symbol: str,
+) -> dict:
+    """Return a summary of the option chain for ``ticker_symbol``.
+
+    Aggregates open interest, volume and implied volatility across all
+    expiration dates and calculates Put/Call ratios.
+    """
+    import yfinance as yf
+
+    symbol = ticker_symbol.upper()
+    try:
+        ticker = yf.Ticker(symbol)
+        expirations = getattr(ticker, "options", [])
+
+        total_call_oi = 0
+        total_put_oi = 0
+        total_call_vol = 0
+        total_put_vol = 0
+        call_iv = []
+        put_iv = []
+
+        for date in expirations:
+            try:
+                chain = ticker.option_chain(date)
+            except Exception:
+                continue
+
+            calls = chain.calls
+            puts = chain.puts
+            total_call_oi += calls["openInterest"].fillna(0).sum()
+            total_put_oi += puts["openInterest"].fillna(0).sum()
+            total_call_vol += calls["volume"].fillna(0).sum()
+            total_put_vol += puts["volume"].fillna(0).sum()
+            call_iv.extend(calls["impliedVolatility"].dropna().tolist())
+            put_iv.extend(puts["impliedVolatility"].dropna().tolist())
+
+        def _avg(values: list[float]):
+            return sum(values) / len(values) if values else None
+
+        avg_call_iv = _avg(call_iv)
+        avg_put_iv = _avg(put_iv)
+        avg_iv = _avg(call_iv + put_iv)
+        pcr_oi = (total_put_oi / total_call_oi) if total_call_oi else None
+        pcr_vol = (total_put_vol / total_call_vol) if total_call_vol else None
+
+        def _round(val):
+            return round(val, 4) if val is not None else None
+
+        return {
+            "call_open_interest": int(total_call_oi),
+            "put_open_interest": int(total_put_oi),
+            "call_volume": int(total_call_vol),
+            "put_volume": int(total_put_vol),
+            "avg_call_iv": _round(avg_call_iv),
+            "avg_put_iv": _round(avg_put_iv),
+            "avg_iv": _round(avg_iv),
+            "pcr_oi": _round(pcr_oi),
+            "pcr_vol": _round(pcr_vol),
+        }
+    except Exception as e:
+        return {"error": f"Failed to retrieve options for {symbol}: {e}"}

--- a/core/services.py
+++ b/core/services.py
@@ -1,5 +1,10 @@
 import yfinance as yf
-from core.calc import calculate_rsi, calculate_ma, calculate_macd
+from core.calc import (
+    calculate_rsi,
+    calculate_ma,
+    calculate_macd,
+    summarize_option_chain,
+)
 
 def get_ticker_data(ticker_symbol: str) -> dict:
     ticker_symbol = ticker_symbol.upper()
@@ -27,6 +32,8 @@ def get_ticker_data(ticker_symbol: str) -> dict:
         ma200 = calculate_ma(close, 200)
         macd_val, macd_signal = calculate_macd(close)
 
+        options_summary = summarize_option_chain(ticker_symbol)
+
         data = {
             "Ticker": ticker_symbol,
             "Value": current_price,
@@ -41,6 +48,7 @@ def get_ticker_data(ticker_symbol: str) -> dict:
             "MA200": ma200,
             "MACD": macd_val,
             "MACD Signal": macd_signal,
+            "Options": options_summary,
         }
 
         return data

--- a/ui/panels/panel_main.py
+++ b/ui/panels/panel_main.py
@@ -1,5 +1,4 @@
 import tkinter as tk
-import json
 from core.services import get_ticker_data
 
 class MainPanel(tk.Frame):
@@ -36,10 +35,11 @@ class MainPanel(tk.Frame):
                     if "error" in data:
                         self.output_text.insert(tk.END, data["error"])
                     else:
-                        self.output_text.insert(tk.END, json.dumps(data, indent=4))
+                        for key, val in data.items():
+                            self.output_text.insert(tk.END, f"{key}: {val}\n")
                     if idx < len(tickers) - 1:
-                        self.output_text.insert(tk.END, "\n")
-                self.save_button.configure(state="normal")
+                        self.output_text.insert(tk.END, "-" * 40 + "\n")
+                    self.save_button.configure(state="normal")
         else:
             self.save_button.configure(state="disabled")
         self.output_text.configure(state="disabled")


### PR DESCRIPTION
## Summary
- compute option chain summary in `core.calc`
- add option chain info when retrieving ticker data
- simplify console output for manual searches

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687faf7a26488325a769514f56f17058