### PR TITLE
Add SPY and UUP context to predictions

### DIFF
--- a/core/calc.py
+++ b/core/calc.py
@@ -11,6 +11,15 @@ def calculate_rsi(series: pd.Series, period: int = 14) -> float | None:
     return round(rsi.iloc[-1], 2) if not rsi.empty else None
 
 
+def rsi_series(series: pd.Series, period: int = 14) -> pd.Series:
+    """Return an RSI series for use in feature engineering."""
+    delta = series.diff()
+    gain = delta.where(delta > 0, 0).rolling(window=period).mean()
+    loss = -delta.where(delta < 0, 0).rolling(window=period).mean()
+    rs = gain / loss
+    return 100 - (100 / (1 + rs))
+
+
 def calculate_ma(series: pd.Series, window: int) -> float | None:
     """Calculate moving average for the given window size."""
     ma = series.rolling(window=window).mean()
@@ -97,7 +106,12 @@ def summarize_option_chain(
         return {"error": f"Failed to retrieve options for {symbol}: {e}"}
 
 
-def random_forest_prediction(series: pd.Series, n_lags: int = 5) -> float | None:
+def random_forest_prediction(
+    series: pd.Series,
+    n_lags: int = 5,
+    spy: pd.Series | None = None,
+    uup: pd.Series | None = None,
+) -> float | None:
     """Return next close price prediction using RandomForestRegressor.
 
     Returns ``None`` if scikit-learn is not available or insufficient data.
@@ -113,9 +127,21 @@ def random_forest_prediction(series: pd.Series, n_lags: int = 5) -> float | None
     df = pd.DataFrame({"Close": series})
     for i in range(1, n_lags + 1):
         df[f"lag_{i}"] = df["Close"].shift(i)
+
+    if spy is not None:
+        df["spy_rsi"] = rsi_series(spy)
+        df["rel_strength"] = series / spy
+
+    if uup is not None:
+        df["uup_rsi"] = rsi_series(uup)
+
     df.dropna(inplace=True)
 
     features = [f"lag_{i}" for i in range(1, n_lags + 1)]
+    if spy is not None:
+        features.extend(["spy_rsi", "rel_strength"])
+    if uup is not None:
+        features.append("uup_rsi")
     X = df[features]
     y = df["Close"]
 
@@ -125,7 +151,12 @@ def random_forest_prediction(series: pd.Series, n_lags: int = 5) -> float | None
     return round(float(pred[0]), 2)
 
 
-def xgboost_prediction(series: pd.Series, n_lags: int = 5) -> float | None:
+def xgboost_prediction(
+    series: pd.Series,
+    n_lags: int = 5,
+    spy: pd.Series | None = None,
+    uup: pd.Series | None = None,
+) -> float | None:
     """Return next close price prediction using XGBoost.
 
     Returns ``None`` if xgboost is not installed or insufficient data.
@@ -141,9 +172,21 @@ def xgboost_prediction(series: pd.Series, n_lags: int = 5) -> float | None:
     df = pd.DataFrame({"Close": series})
     for i in range(1, n_lags + 1):
         df[f"lag_{i}"] = df["Close"].shift(i)
+
+    if spy is not None:
+        df["spy_rsi"] = rsi_series(spy)
+        df["rel_strength"] = series / spy
+
+    if uup is not None:
+        df["uup_rsi"] = rsi_series(uup)
+
     df.dropna(inplace=True)
 
     features = [f"lag_{i}" for i in range(1, n_lags + 1)]
+    if spy is not None:
+        features.extend(["spy_rsi", "rel_strength"])
+    if uup is not None:
+        features.append("uup_rsi")
     X = df[features]
     y = df["Close"]
 

--- a/core/services.py
+++ b/core/services.py
@@ -28,14 +28,22 @@ def get_ticker_data(ticker_symbol: str) -> dict:
         if hist.empty:
             return {"error": f"Error: [{ticker_symbol}] not found"}
         close = hist["Close"]
+
+        # fetch market context
+        spy = yf.Ticker("SPY").history(period="1y")["Close"]
+        uup = yf.Ticker("UUP").history(period="1y")["Close"]
+
         rsi = calculate_rsi(close)
+        spy_rsi = calculate_rsi(spy)
+        uup_rsi = calculate_rsi(uup)
+        rel_strength = round(close.iloc[-1] / spy.iloc[-1], 4) if not spy.empty else None
+
         ma20 = calculate_ma(close, 20)
         ma50 = calculate_ma(close, 50)
         ma200 = calculate_ma(close, 200)
         macd_val, macd_signal = calculate_macd(close)
-
-        rf_pred = random_forest_prediction(close)
-        xgb_pred = xgboost_prediction(close)
+        rf_pred = random_forest_prediction(close, spy=spy, uup=uup)
+        xgb_pred = xgboost_prediction(close, spy=spy, uup=uup)
 
         options_summary = summarize_option_chain(ticker_symbol)
 
@@ -48,6 +56,9 @@ def get_ticker_data(ticker_symbol: str) -> dict:
             "Day High": day_high,
             "Volume": volume,
             "RSI": rsi,
+            "SPY RSI": spy_rsi,
+            "UUP RSI": uup_rsi,
+            "Relative Strength": rel_strength,
             "MA20": ma20,
             "MA50": ma50,
             "MA200": ma200,


### PR DESCRIPTION
## Summary
- compute RSI series for feature engineering
- use SPY and UUP RSI plus relative strength in prediction models
- fetch SPY and UUP data in `get_ticker_data`

## Testing
- `python -m py_compile core/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6880aabd3f2483259945b0a91171122c